### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.makeramen:roundedimageview:2.3.0'
+    implementation("com.makeramen:roundedimageview:2.3.0")
 }
 ```
 


### PR DESCRIPTION
Replaced compile with implementation.

compile is now deprecated: https://developer.android.com/build/dependencies